### PR TITLE
docs: Exclude Beast ORM from optimizeDeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,8 +839,6 @@ The delete method, conveniently, is named delete(). This method immediately dele
 Session.delete();
 ```
 
-## Menggunakan Beast ORM pada Vite
-
 ## Using Beast ORM with Vite
 
 Exclude Beast ORM from optimizeDeps

--- a/README.md
+++ b/README.md
@@ -2,126 +2,127 @@
 
 ORM for accessing indexedDB and localStorage.
 
-
 ## DBMS Support
 
 - IndexedDB
 - Sqlite **(Will be publish in version 2.0.0)**
-- localstorage 
+- localstorage
 
 <br/>
 
 ### Details
+
 - The indexedDB implementation runs multiple request in a single transaction
 
-#### A promise base api implementation for accessing for accessing indexedDB 
+#### A promise base api implementation for accessing for accessing indexedDB
+
 ## Create model
 
 A model is a representation of a database table. Feel free to place your models anywhere that can be exported
 
 ```javascript
-import { models } from 'beast-orm';
+import { models } from "beast-orm";
 
 class User extends models.Model {
-
-  userId = models.AutoField({primaryKey:true})
-  username = models.CharField({maxLength: 100})
-  email = models.CharField({blank: true, maxLength: 100})
-  age = models.IntegerField()
+  userId = models.AutoField({ primaryKey: true });
+  username = models.CharField({ maxLength: 100 });
+  email = models.CharField({ blank: true, maxLength: 100 });
+  age = models.IntegerField();
 }
-
 ```
 
 <br/>
 
 ## Register model
+
 Once you’ve register your data models, automatically gives you a database-abstraction API for accessing indexedDB as a promise base api implementation that lets you create, retrieve, update and delete objects. Models that belongs to the same database should be register at the same time.
 
 ```javascript
-import { models } from 'beast-orm';
-import { User } from './models/user.js';
+import { models } from "beast-orm";
+import { User } from "./models/user.js";
 
 models.register({
-  databaseName: 'tutorial',
+  databaseName: "tutorial",
   version: 1,
-  type: 'indexedDB',
-  models: [User]
-})
-
+  type: "indexedDB",
+  models: [User],
+});
 ```
 
 <br/>
 
 ## Creating objects
 
-
 An instance of that class represents a particular record in the database table
-```javascript
-const user = await User.create({username:'kobe', email:'kobe.bryant@lakers.com'})
 
+```javascript
+const user = await User.create({
+  username: "kobe",
+  email: "kobe.bryant@lakers.com",
+});
 ```
 
 To add multiple records in one go
+
 ```javascript
 const users = [
-  {username:'kobe', email:'kobe.bryant@forever.com', age: 30},
-  {username:'michael', email:'michael.jackson@forever.com', age: 30}
-]
+  { username: "kobe", email: "kobe.bryant@forever.com", age: 30 },
+  { username: "michael", email: "michael.jackson@forever.com", age: 30 },
+];
 
-const users = await User.create(users)
-
+const users = await User.create(users);
 ```
+
 ## Saving changes to objects
+
 this example changes its name and updates its record in the database
 
 ```javascript
-
-const u1 = await User.get({userId:1})
-u1.username = 'New name'
-u1.save()
-
+const u1 = await User.get({ userId: 1 });
+u1.username = "New name";
+u1.save();
 ```
-
 
 <br/>
 
 ## Retrieving objects
-The query is not executed as soon as the function is called 
+
+The query is not executed as soon as the function is called
+
 ### Retrieving all objects
-The simplest way to retrieve objects from a table is to get all of them. To do this, use the all() 
+
+The simplest way to retrieve objects from a table is to get all of them. To do this, use the all()
+
 ```javascript
-User.all()
+User.all();
 ```
 
 <br/>
 
 ### Retrieving specific objects with filters
 
-#### 
+####
 
-**Filter**  - returns objects that match the given lookup parameters.
+**Filter** - returns objects that match the given lookup parameters.
 
-**get** - return object that match the given lookup 
+**get** - return object that match the given lookup
 
 parameters.
 
 ```javascript
+const user = await User.get({ username: "kobe" });
 
-const user = await User.get({username:'kobe'})
-
-console.log(user.username) // kobe
-
+console.log(user.username); // kobe
 ```
+
 **get** only works with unique fields
 
-
 Filter can have complex lookup parameters
+
 ```javascript
-
-const users = await User.filter({age:10}).execute()
-
-
+const users = await User.filter({ age: 10 }).execute();
 ```
+
 **Field lookup**
 
 - **gt** - greater
@@ -133,41 +134,50 @@ const users = await User.filter({age:10}).execute()
 Example:
 
 ```javascript
-
-const users = await User.filter({age__gt: 10}).execute()
+const users = await User.filter({ age__gt: 10 }).execute();
 // sql Select * from User Where age > 10
 
-const users = await User.filter({age__gt: 10, age__lt: 50}).execute()
+const users = await User.filter({ age__gt: 10, age__lt: 50 }).execute();
 // sql Select * from User Where age > 10 AND  age < 50
 
-const users = await User.filter({age: 10, age__lt: 50}, {username: 'kobe'}).execute()
+const users = await User.filter(
+  { age: 10, age__lt: 50 },
+  { username: "kobe" }
+).execute();
 // sql Select * from User Where age = 10 AND  age < 50 OR username = 'kobe'
 
-const users = await User.filter({age__not: 10}, [{age: 20},{username:'james'}]).execute()
+const users = await User.filter({ age__not: 10 }, [
+  { age: 20 },
+  { username: "james" },
+]).execute();
 // sql Select * from User Where not age = 10  OR (age = 20 OR username = 'james')
-
 ```
+
 ### Saving changes to objects
+
 To save changes to an object that’s already in the database, use save().
-```javascript
 
-  const user = await User.get({username:'kobe'})
-  user.username = 'james'
-  user.save()
+```javascript
+const user = await User.get({ username: "kobe" });
+user.username = "james";
+user.save();
 ```
+
 ### Updating multiple objects at once
-Sometimes you want to set a field to a particular value for all the objects 
-You can do this with the update() method. For example:
-```javascript
 
-  User.filter({age:10}).update({age:11})
+Sometimes you want to set a field to a particular value for all the objects
+You can do this with the update() method. For example:
+
+```javascript
+User.filter({ age: 10 }).update({ age: 11 });
 ```
+
 ### Deleting objects
 
 The delete method, conveniently, is named delete(). This method immediately deletes the object
 
 ```javascript
-  User.delete()
+User.delete();
 ```
 
 You can also delete objects in bulk. Every QuerySet has a delete() method, which deletes all members of that QuerySet.
@@ -175,59 +185,60 @@ You can also delete objects in bulk. Every QuerySet has a delete() method, which
 For example, this deletes all User objects with a age 40, and returns the number of objects deleted.
 
 ```javascript
-  User.filter({age: 40}).delete()
+User.filter({ age: 40 }).delete();
 ```
 
 <br/>
 <br/>
-
 
 ## ArrayField
 
 A field for storing lists of data. Most field types can be used, and you pass another field instance. You may also specify a size. ArrayField can be nested to store multi-dimensional arrays.
 
 If you give the field a default, ensure it’s a callable such as list (for an empty default) or a callable that returns a list (such as a function). Incorrectly using default:[] creates a mutable default that is shared between all instances of ArrayField.
-```javascript
 
-const { ArrayField } = models.indexedDB.fields
+```javascript
+const { ArrayField } = models.indexedDB.fields;
 
 class ChessBoardUser extends models.Model {
   board = ArrayField({
     field: ArrayField({
-      field: models.CharField({maxLength:10, blank:true}),
-      size:8,
+      field: models.CharField({ maxLength: 10, blank: true }),
+      size: 8,
     }),
-    size:8,
-  })
+    size: 8,
+  });
 }
 
 models.register({
-  databaseName: 'tutorial-ArrayField',
+  databaseName: "tutorial-ArrayField",
   version: 1,
-  type: 'indexedDB',
-  models: [ChessBoardUser]
-})
+  type: "indexedDB",
+  models: [ChessBoardUser],
+});
 
 // valid
 ChessBoardUser.create({
   board: [
-    ['01','02','03','04','05','06','07','08'],
-    ['21','22','23','24','25','26','27','28'],
-    ['31','32','33','34','35','36','37','38'],
-    ['41','42','43','44','45','46','47','48'],
-    ['51','52','53','54','55','56','57','58'],
-    ['61','62','63','64','65','66','67','68'],
-    ['71','72','73','74','75','76','77','78'],
-    ['81','82','83','84','85','86','87','88'],
-  ]
-})
-
+    ["01", "02", "03", "04", "05", "06", "07", "08"],
+    ["21", "22", "23", "24", "25", "26", "27", "28"],
+    ["31", "32", "33", "34", "35", "36", "37", "38"],
+    ["41", "42", "43", "44", "45", "46", "47", "48"],
+    ["51", "52", "53", "54", "55", "56", "57", "58"],
+    ["61", "62", "63", "64", "65", "66", "67", "68"],
+    ["71", "72", "73", "74", "75", "76", "77", "78"],
+    ["81", "82", "83", "84", "85", "86", "87", "88"],
+  ],
+});
 ```
+
 <br/>
 <br/>
 
 ### Querying ArrayField
+
 There are a number of custom lookups and transforms for ArrayField. We will use the following example model:
+
 ```javascript
 
 const { ArrayField } = models.indexedDB.fields
@@ -239,126 +250,130 @@ class Post extends models.Model {
 
 
 ```
+
 <br/>
 <br/>
 
 ### contains
+
 The contains lookup is overridden on ArrayField. The returned objects will be those where the values passed are a subset of the data. It uses the SQL operator @>. For example:
 
 ```javascript
+Post.create({ name: "First post", tags: ["thoughts", "django"] });
+Post.create({ name: "Second post", tags: ["thoughts"] });
+Post.create({ name: "Third post", tags: ["tutorial", "django"] });
 
-Post.create({name:'First post', tags:['thoughts', 'django']})
-Post.create({name:'Second post', tags:['thoughts']})
-Post.create({name:'Third post', tags:['tutorial', 'django']})
-
-Post.filter({tags__contains:['thoughts']}).execute()
+Post.filter({ tags__contains: ["thoughts"] }).execute();
 // [<Post: First post>, <Post: Second post>]
 
-Post.filter({tags__contains:['django']}).execute()
+Post.filter({ tags__contains: ["django"] }).execute();
 // [<Post: First post>, <Post: Third post>]
 
-Post.filter({tags__contains:['django', 'thoughts']}).execute()
+Post.filter({ tags__contains: ["django", "thoughts"] }).execute();
 // [<Post: First post>]
-
-
 ```
+
 <br/>
 <br/>
 
 ### contained_by
+
 This is the inverse of the contains lookup - the objects returned will be those where the data is a subset of the values passed. It uses the SQL operator <@. For example:
 
 ```javascript
-Post.create({name:'First post', tags:['thoughts', 'django']}).execute()
-Post.create({name:'Second post', tags:['thoughts']}).execute()
-Post.create({name:'Third post', tags:['tutorial', 'django']}).execute()
+Post.create({ name: "First post", tags: ["thoughts", "django"] }).execute();
+Post.create({ name: "Second post", tags: ["thoughts"] }).execute();
+Post.create({ name: "Third post", tags: ["tutorial", "django"] }).execute();
 
-Post.filter({tags__contained_by:['thoughts', 'django']}).execute()
+Post.filter({ tags__contained_by: ["thoughts", "django"] }).execute();
 // <Post: First post>, <Post: Second post>]
 
-Post.filter({tags__contained_by:['thoughts', 'django', 'tutorial']}).execute()
+Post.filter({
+  tags__contained_by: ["thoughts", "django", "tutorial"],
+}).execute();
 // [<Post: First post>, <Post: Second post>, <Post: Third post>]
-
-
 ```
 
 ### overlap
+
 Returns objects where the data shares any results with the values passed. Uses the SQL operator &&. For example:s the SQL operator <@. For example:
 
 ```javascript
-Post.create({name:'First post', tags:['thoughts', 'django']}).execute()
-Post.create({name:'Second post', tags:['thoughts']}).execute()
-Post.create({name:'Third post', tags:['tutorial', 'django']}).execute()
+Post.create({ name: "First post", tags: ["thoughts", "django"] }).execute();
+Post.create({ name: "Second post", tags: ["thoughts"] }).execute();
+Post.create({ name: "Third post", tags: ["tutorial", "django"] }).execute();
 
-Post.filter({tags__overlap:['thoughts']}).execute()
+Post.filter({ tags__overlap: ["thoughts"] }).execute();
 // [<Post: First post>, <Post: Second post>]
 
-Post.filter({tags__overlap:['thoughts', 'tutorial']}).execute()
+Post.filter({ tags__overlap: ["thoughts", "tutorial"] }).execute();
 // [<Post: First post>, <Post: Second post>, <Post: Third post>]
-
-
 ```
-<br/>
-<br/>
 
+<br/>
+<br/>
 
 ### len
+
 Returns the length of the array. The lookups available afterward are those available for IntegerField. For example:
 
 ```javascript
-Post.create({name:'First post', tags:['thoughts', 'django']})
-Post.create({name:'Second post', tags:['thoughts']})
+Post.create({ name: "First post", tags: ["thoughts", "django"] });
+Post.create({ name: "Second post", tags: ["thoughts"] });
 
-Post.filter(tags__len=1).execute()
+Post.filter((tags__len = 1)).execute();
 // [<Post: Second post>]
-
-
 ```
-<br/>
-<br/>
 
+<br/>
+<br/>
 
 ### Index transforms
+
 Index transforms index into the array. Any non-negative integer can be used. There are no errors if it exceeds the size of the array. The lookups available after the transform are those from the base_field. For example:
 
 ```javascript
+Post.create({ name: "First post", tags: ["thoughts", "django"] });
+Post.create({ name: "Second post", tags: ["thoughts"] });
 
-Post.create({name:'First post', tags:['thoughts', 'django']})
-Post.create({name:'Second post', tags:['thoughts']})
-
-Post.filter({tags__0:'thoughts'}).execute()
+Post.filter({ tags__0: "thoughts" }).execute();
 // [<Post: First post>, <Post: Second post>]
 
-Post.filter({tags__1__iexact:'Django'}).execute()
+Post.filter({ tags__1__iexact: "Django" }).execute();
 // [<Post: First post>]
 
-Post.filter({tags__276:'javascript'}).execute()
+Post.filter({ tags__276: "javascript" }).execute();
 // []
 ```
+
 <br>
 <br>
 
 ## JSONField
+
 Lookups implementation is different in JSONField, mainly due to the existence of key transformations. To demonstrate, we will use the following example model:
+
 ```javascript
-const { JsonField } = models.indexedDB.fields
+const { JsonField } = models.indexedDB.fields;
 
 class Dog extends models.Model {
-  name = models.CharField({maxLength:200})
-  data = JsonField({null: false})
+  name = models.CharField({ maxLength: 200 });
+  data = JsonField({ null: false });
 }
 
 models.register({
-  databaseName: 'tutorial-JsonField',
+  databaseName: "tutorial-JsonField",
   version: 1,
-  type: 'indexedDB',
-  models: [Dog]
-})
+  type: "indexedDB",
+  models: [Dog],
+});
 ```
+
 <br/>
 <br/>
 
 ### Storing and querying for None
+
 As with other fields, storing None as the field’s value will store it as SQL NULL. While not recommended, it is possible to store JSON scalar null instead of SQL NULL by using Value('null').
 
 Whichever of the values is stored, when retrieved from the database, the Python representation of the JSON scalar null is the same as SQL NULL, i.e. None. Therefore, it can be hard to distinguish between them.
@@ -366,6 +381,7 @@ Whichever of the values is stored, when retrieved from the database, the Python 
 This only applies to None as the top-level value of the field. If None is inside a list or dict, it will always be interpreted as JSON null.
 
 When querying, None value will always be interpreted as JSON null. To query for SQL NULL, use isnull:
+
 ```javascript
 
 Dog.create({name:'Max', data: null})  # SQL NULL.
@@ -383,106 +399,111 @@ Dog.filter({data__isnull:false}).execute()
 ```
 
 ### Key, index, and path transforms
+
 To query based on a given dictionary key, use that key as the lookup name:
 
 ```javascript
-
-Dog.create({name:'Rufus', data: {
-  'breed': 'labrador',
-  'owner': {
-    'name': 'Bob',
-    'other_pets': [{
-      'name': 'Fishy',
-    }],
+Dog.create({
+  name: "Rufus",
+  data: {
+    breed: "labrador",
+    owner: {
+      name: "Bob",
+      other_pets: [
+        {
+          name: "Fishy",
+        },
+      ],
+    },
   },
-}})
+});
 
-Dog.create({name:'Meg', data:{'breed': 'collie', 'owner': null}})
+Dog.create({ name: "Meg", data: { breed: "collie", owner: null } });
 // <Dog: Meg>
-Dog.filter({data__breed:'collie'}).execute()
+Dog.filter({ data__breed: "collie" }).execute();
 // [<Dog: Meg>]
 ```
 
-
 Multiple keys can be chained together to form a path lookup:
-```javascript
 
-Dog.objects.filter({data__owner__name:'Bob'}).execute()
+```javascript
+Dog.objects.filter({ data__owner__name: "Bob" }).execute();
 // [<Dog: Rufus>]
 ```
 
 If the key is an integer, it will be interpreted as an index transform in an array:
 
 ```javascript
-
-Dog.objects.filter({data__owner__other_pets__0__name:'Fishy'}).execute()
+Dog.objects.filter({ data__owner__other_pets__0__name: "Fishy" }).execute();
 // [<Dog: Rufus>]
 ```
 
 If the key you wish to query by clashes with the name of another lookup, use the contains lookup instead.
 
 To query for missing keys, use the isnull lookup:
-```javascript
-Dog.objects.create({name:'Shep', data:{'breed': 'collie'}})
 
-Dog.objects.filter({data__owner__isnull:true}).execute()
+```javascript
+Dog.objects.create({ name: "Shep", data: { breed: "collie" } });
+
+Dog.objects.filter({ data__owner__isnull: true }).execute();
 // [<Dog: Shep>]
 ```
+
 Note
 
 The lookup examples given above implicitly use the exact lookup. Key, index, and path transforms can also be chained with: icontains, endswith, iendswith, iexact, regex, iregex, startswith, istartswith, lt, lte, gt, and gte, as well as with Containment and key lookups.
 <br/>
 <br/>
 
-
 ### contains
 
 The contains lookup is overridden on JSONField. The returned objects are those where the given dict of key-value pairs are all contained in the top-level of the field. For example:
 
-
 ```javascript
-Dog.create({name:'Rufus', data:{'breed': 'labrador', 'owner': 'Bob'}})
+Dog.create({ name: "Rufus", data: { breed: "labrador", owner: "Bob" } });
 // <Dog: Rufus>
-Dog.create({name:'Meg', data:{'breed': 'collie', 'owner': 'Bob'}})
+Dog.create({ name: "Meg", data: { breed: "collie", owner: "Bob" } });
 // <Dog: Meg>
-Dog.create({name:'Fred', data:{}})
+Dog.create({ name: "Fred", data: {} });
 // <Dog: Fred>
-Dog.filter({data__contains:{'owner': 'Bob'}}).execute()
+Dog.filter({ data__contains: { owner: "Bob" } }).execute();
 // [<Dog: Rufus>, <Dog: Meg>]
-Dog.filter({data__contains:{'breed': 'collie'}}).execute()
+Dog.filter({ data__contains: { breed: "collie" } }).execute();
 // [<Dog: Meg>]
 ```
 
-
 ### contained_by
+
 This is the inverse of the contains lookup - the objects returned will be those where the key-value pairs on the object are a subset of those in the value passed. For example:
 
-
 ```javascript
-Dog.create({name:'Rufus', data:{'breed': 'labrador', 'owner': 'Bob'}})
-Dog.create({name:'Meg', data:{'breed': 'collie', 'owner': 'Bob'}})
-Dog.create({name:'Fred', data:{}})
+Dog.create({ name: "Rufus", data: { breed: "labrador", owner: "Bob" } });
+Dog.create({ name: "Meg", data: { breed: "collie", owner: "Bob" } });
+Dog.create({ name: "Fred", data: {} });
 
-Dog.filter({data__contained_by:{'breed': 'collie', 'owner': 'Bob'}}).execute()
+Dog.filter({ data__contained_by: { breed: "collie", owner: "Bob" } }).execute();
 // [<Dog: Meg>, <Dog: Fred>]
-Dog.filter({data__contained_by:{'breed': 'collie'}}).execute()
+Dog.filter({ data__contained_by: { breed: "collie" } }).execute();
 // [<Dog: Fred>]
 ```
 
 ### has_key
+
 Returns objects where the given key is in the top-level of the data. For example:
 
 ```javascript
-Dog.create({name:'Rufus', data:{'breed': 'labrador'}})
+Dog.create({ name: "Rufus", data: { breed: "labrador" } });
 // [<Dog: Rufus>]
-Dog.create({name:'Meg', data:{'breed': 'collie', 'owner': 'Bob'}})
+Dog.create({ name: "Meg", data: { breed: "collie", owner: "Bob" } });
 // [<Dog: Meg>]
-Dog.filter({data__has_key:'owner'}).execute()
+Dog.filter({ data__has_key: "owner" }).execute();
 // [<Dog: Meg>]
 ```
 
 ### has_keys
+
 Returns objects where all of the given keys are in the top-level of the data. For example:
+
 ```javascript
 Dog.create(name:'Rufus', data:{'breed': 'labrador'})
 // [<Dog: Rufus>]
@@ -491,36 +512,40 @@ Dog.create({name:'Meg', data:{'breed': 'collie', 'owner': 'Bob'}})
 Dog.filter({data__has_keys:['breed', 'owner']})
 // [<Dog: Meg>]
 ```
+
 ### has_any_keys
+
 Returns objects where any of the given keys are in the top-level of the data. For example:
+
 ```javascript
-Dog.create({name:'Rufus', data:{'breed': 'labrador'}})
+Dog.create({ name: "Rufus", data: { breed: "labrador" } });
 // [<Dog: Rufus>]
-Dog.create({name:'Meg', data:{'owner': 'Bob'}})
+Dog.create({ name: "Meg", data: { owner: "Bob" } });
 // [<Dog: Meg>]
-Dog.filter({data__has_any_keys:['owner', 'breed']})
+Dog.filter({ data__has_any_keys: ["owner", "breed"] });
 // [<Dog: Rufus>, <Dog: Meg>]
 ```
+
 ## Many-to-many relationships
+
 In this example, an Article can be published in multiple Publication objects, and a Publication has multiple Article objects:
+
 ```javascript
 class Publication extends models.Model {
-  title = models.CharField({maxLength: 50})
+  title = models.CharField({ maxLength: 50 });
 }
 
-
 class Article extends models.Model {
-  headline = models.CharField({maxLength: 100})
-  publication = models.ManyToManyField({model:Publication})
+  headline = models.CharField({ maxLength: 100 });
+  publication = models.ManyToManyField({ model: Publication });
 }
 
 models.register({
-  databaseName:'One-to-one-relationships',
-  type: 'indexedDB',
+  databaseName: "One-to-one-relationships",
+  type: "indexedDB",
   version: 1,
-  models: [Publication, Article]
-})
-
+  models: [Publication, Article],
+});
 ```
 
 What follows are examples of operations that can be performed using the Python API facilities.
@@ -528,58 +553,58 @@ What follows are examples of operations that can be performed using the Python A
 Create a few Publications:
 
 ```javascript
-  const  p1 = await Publication.create({title:'The Python Journal'})
-  const  p2 = await Publication.create({title:'Science News'})
-  const  p3 = await Publication.create({title:'Science Weekly'})
-
+const p1 = await Publication.create({ title: "The Python Journal" });
+const p2 = await Publication.create({ title: "Science News" });
+const p3 = await Publication.create({ title: "Science Weekly" });
 ```
 
 Create an Article:
-```javascript
-  const a1 = await Article.create({headline:'lets you build web apps easily'})
-  const a2 = await Article.create({headline:'NASA uses Python'})
 
+```javascript
+const a1 = await Article.create({ headline: "lets you build web apps easily" });
+const a2 = await Article.create({ headline: "NASA uses Python" });
 ```
 
 Associate the Article with a Publication:
-```javascript
-  await a1.publication_add([p1, p2])
 
+```javascript
+await a1.publication_add([p1, p2]);
 ```
+
 Article objects have access to their related Publication objects:
-```javascript
-  await a1.publication_all()
 
+```javascript
+await a1.publication_all();
 ```
+
 Article objects have access to their related Publication objects:
+
 ```javascript
-  await p1.article_set_all()
-
+await p1.article_set_all();
 ```
-
 
 ## One-to-one relationships
+
 In this example, a Place optionally can be a Restaurant:
+
 ```javascript
 class Place extends models.Model {
-  name = models.CharField({maxLength: 50})
-  address = models.CharField({maxLength: 50})
-} 
-
-class Restaurant extends models.Model  {
-  place = models.OneToOneField({model:Place})
-  servesHotDogs = models.BooleanField({default: false})
-  servesPizza = models.BooleanField({default: false})
+  name = models.CharField({ maxLength: 50 });
+  address = models.CharField({ maxLength: 50 });
 }
 
+class Restaurant extends models.Model {
+  place = models.OneToOneField({ model: Place });
+  servesHotDogs = models.BooleanField({ default: false });
+  servesPizza = models.BooleanField({ default: false });
+}
 
 await models.register({
-  databaseName:'jest-test'+ new Date().getTime(),
-  type: 'indexedDB',
+  databaseName: "jest-test" + new Date().getTime(),
+  type: "indexedDB",
   version: 1,
-  models: [Place, Restaurant]
-})
-
+  models: [Place, Restaurant],
+});
 ```
 
 What follows are examples of operations that can be performed using the Python API facilities.
@@ -587,51 +612,55 @@ What follows are examples of operations that can be performed using the Python A
 Create a couple of Places:
 
 ```javascript
-  const p1 = await Place.create({name:'Demon Dogs', address:'944 W. Fullerton'})
-
+const p1 = await Place.create({
+  name: "Demon Dogs",
+  address: "944 W. Fullerton",
+});
 ```
 
 Create a Restaurant. Pass the “parent” object as this object’s primary key:
 
 ```javascript
-  const r = await Restaurant.create({place:p1, servesHotDogs: false, servesPizza:false})
-
+const r = await Restaurant.create({
+  place: p1,
+  servesHotDogs: false,
+  servesPizza: false,
+});
 ```
 
 A Restaurant can access its place:
-```javascript
-  const r = await p1.Restaurant()
 
+```javascript
+const r = await p1.Restaurant();
 ```
 
 A Place can access its restaurant, if available:
+
 ```javascript
-  const p = await await r.Place()
+const p = await await r.Place();
 ```
 
 ## many-to-one relationships
 
 ```javascript
 class Reporter extends models.Model {
-  firstName = models.CharField({maxLength: 50})
-  lastName = models.CharField({maxLength: 50})
-  email = models.CharField()
+  firstName = models.CharField({ maxLength: 50 });
+  lastName = models.CharField({ maxLength: 50 });
+  email = models.CharField();
 }
 
 class Article extends models.Model {
-  headline = models.CharField({maxLength: 50})
-  pubDate = models.DateField()
-  reporter = models.ForeignKey({model:Reporter})
+  headline = models.CharField({ maxLength: 50 });
+  pubDate = models.DateField();
+  reporter = models.ForeignKey({ model: Reporter });
 }
 
-
 await models.register({
-  databaseName:'jest-test'+ new Date().getTime(),
-  type: 'indexedDB',
+  databaseName: "jest-test" + new Date().getTime(),
+  type: "indexedDB",
   version: 1,
-  models: [Reporter, Article]
-})
-
+  models: [Reporter, Article],
+});
 ```
 
 What follows are examples of operations that can be performed using the Python API facilities.
@@ -639,135 +668,156 @@ What follows are examples of operations that can be performed using the Python A
 Create a few Reporters:
 
 ```javascript
-const r1 = await Reporter.create({firstName: 'asdfsadf', lastName: 'asdfsd', email:'teste'})
-const r2 = await Reporter.create({firstName: 'Peter', lastName: 'Maquiran', email:'teste'})
-
+const r1 = await Reporter.create({
+  firstName: "asdfsadf",
+  lastName: "asdfsd",
+  email: "teste",
+});
+const r2 = await Reporter.create({
+  firstName: "Peter",
+  lastName: "Maquiran",
+  email: "teste",
+});
 ```
 
 Create an Article:
 
 ```javascript
-  const a = await Article.create({headline:"This is a test", pubDate:'', reporter:r1})
-
+const a = await Article.create({
+  headline: "This is a test",
+  pubDate: "",
+  reporter: r1,
+});
 ```
 
 Article objects have access to their related Reporter objects:
-```javascript
-  const r1 = await a.Reporter()
 
+```javascript
+const r1 = await a.Reporter();
 ```
 
 Reporter objects have access to their related Article objects:
-```javascript
-  const a = await await r1.article_setAll()
 
+```javascript
+const a = await await r1.article_setAll();
 ```
 
 Add the same article to a different article set
-```javascript
-  const a = await await r1.article_setAdd({headline:"This is a test", pubDate:''})
-
-```
-## Reactive List 
 
 ```javascript
-  class Person extends models.Model {
-    username = models.CharField({})  
-    age = models.IntegerField({blank:true})
-  }
- 
-  models.migrate({
-    databaseName:'jest-test',
-    type: 'indexedDB',
-    version: 1,
-    models: [Person]
-  })
-
-
+const a = await await r1.article_setAdd({
+  headline: "This is a test",
+  pubDate: "",
+});
 ```
+
+## Reactive List
+
+```javascript
+class Person extends models.Model {
+  username = models.CharField({});
+  age = models.IntegerField({ blank: true });
+}
+
+models.migrate({
+  databaseName: "jest-test",
+  type: "indexedDB",
+  version: 1,
+  models: [Person],
+});
+```
+
 Create a reactive List that update when a transaction is committed on the database.
+
 ```javascript
-  const PersonList = Person.ReactiveList((model)=> model.all())
-  const PersonAge5List = Person.ReactiveList((model)=> model.filter({age: 5}).execute())
+const PersonList = Person.ReactiveList((model) => model.all());
+const PersonAge5List = Person.ReactiveList((model) =>
+  model.filter({ age: 5 }).execute()
+);
 ```
 
 Get the value
+
 ```javascript
-  PersonList.value
+PersonList.value;
 // [<Person: Rufus>, <Person: Meg>]
 ```
 
 unsubscribe the reactive list
+
 ```javascript
-  PersonList.unsubscribe()
+PersonList.unsubscribe();
 ```
 
 ## Trigger transaction
-```javascript
-  class Person extends models.Model {
-    username = models.CharField({})  
-  }
- 
-  models.migrate({
-    databaseName:'jest-test',
-    type: 'indexedDB',
-    version: 1,
-    models: [Person]
-  })
 
+```javascript
+class Person extends models.Model {
+  username = models.CharField({});
+}
+
+models.migrate({
+  databaseName: "jest-test",
+  type: "indexedDB",
+  version: 1,
+  models: [Person],
+});
 ```
 
 Create a callback function that fire every time a commit is made in the Person
+
 ```javascript
-  let subscription = Person.transactionOnCommit( async () => {
-    console.log('commit')
-  })
+let subscription = Person.transactionOnCommit(async () => {
+  console.log("commit");
+});
 ```
 
 unsubscribe
+
 ```javascript
-  subscription.unsubscribe()
+subscription.unsubscribe();
 ```
 
-## Trigger { BEFORE | AFTER } { INSERT  | UPDATE  | DELETE}
- coming soon
- 
+## Trigger { BEFORE | AFTER } { INSERT | UPDATE | DELETE}
+
+coming soon
+
 <br>
 <br>
 <br>
 
 # LocalStorage base api implementation.
 
-
 ## Create model
 
 A model is a representation of a database table. Feel free to place your models anywhere that can be exported
 
 ```javascript
-import { models } from 'beast-orm';
+import { models } from "beast-orm";
 
 class Session extends models.LocalStorage {
-  static username = ''  
-  static userId = 55
-  static token = ''
-} 
+  static username = "";
+  static userId = 55;
+  static token = "";
+}
 ```
 
 <br/>
 
 ## Register model
+
 Once you’ve register your data models, automatically gives you a abstraction API for accessing local storage base api implementation that lets you create, retrieve, update and delete object.
 
 ```javascript
-import { models } from 'beast-orm';
-import { Session } from './models/user.js';
+import { models } from "beast-orm";
+import { Session } from "./models/user.js";
 
 models.migrate({
-  databaseName: 'tutorial',
+  databaseName: "tutorial",
   version: 1,
-  type: 'indexedDB',
-  models: [Session]
-})
+  type: "indexedDB",
+  models: [Session],
+});
 ```
 
 ## Creating objects or Update
@@ -775,10 +825,10 @@ models.migrate({
 Change Session and save the changes, it will create the key value to the local storage in case it doesn't exist or simple update the value
 
 ```javascript
-Session.username = 'kobe'
-Session.userId = '1'
-Session.token = 'fjif8382'
-Session.save()
+Session.username = "kobe";
+Session.userId = "1";
+Session.token = "fjif8382";
+Session.save();
 ```
 
 ## Deleting objects
@@ -786,10 +836,38 @@ Session.save()
 The delete method, conveniently, is named delete(). This method immediately deletes the object and returns the number of objects deleted and a dictionary with the number of deletions per object type. Example:
 
 ```javascript
-  Session.delete()
+Session.delete();
 ```
 
+## Menggunakan Beast ORM pada Vite
+
+## Using Beast ORM with Vite
+
+Exclude Beast ORM from optimizeDeps
+
+```javascript
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ["beast-orm"],
+  },
+  plugins: [svelte()],
+});
+```
+
+In the configuration above, we are utilizing Beast ORM with Vite. To optimize the dependencies using `optimizeDeps`, we have excluded the "beast-orm" module. This can be beneficial in scenarios where you want to manage the optimization process manually or if there are issues with the optimization of Beast ORM.
+
+The `defineConfig` function is used to create a Vite configuration object. The `optimizeDeps` property allows us to configure dependency optimization, and by specifying the "beast-orm" module in the `exclude` array, we are instructing Vite to exclude it from the optimization process.
+
+Additionally, the configuration includes the Svelte plugin, as indicated by the `plugins` array. Ensure that the dependencies and versions specified in your project are compatible and up-to-date.
+
+Feel free to customize this configuration based on your specific project requirements and dependencies.
+
 ## Languages and Tools
+
 <p align="left">   <a href="https://git-scm.com/" target="_blank"> <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/>  </a> <a href="https://jestjs.io" target="_blank"> <img src="https://www.vectorlogo.zone/logos/jestjsio/jestjsio-icon.svg" alt="jest" width="40" height="40"/> </a>    <a href="https://github.com/puppeteer/puppeteer" target="_blank"> <img src="https://www.vectorlogo.zone/logos/pptrdev/pptrdev-official.svg" alt="puppeteer" width="40" height="40"/>  </a>  <a href="https://www.typescriptlang.org/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="typescript" width="40" height="40"/> </a>
 </p>
 


### PR DESCRIPTION
In this commit, we exclude the "beast-orm" module from the optimizeDeps configuration in Vite. By doing so, we prevent Vite from optimizing the dependency, providing manual control over the optimization process for Beast ORM.

This exclusion is beneficial in cases where manual optimization is preferred or if there are issues related to the optimization of Beast ORM. Developers should ensure that the dependencies and their versions are compatible and up-to-date.

The configuration uses the defineConfig function to create a Vite configuration object. The optimizeDeps property is utilized to configure dependency optimization, and the "beast-orm" module is specified in the exclude array to indicate its exclusion from the optimization process.

Additionally, the Svelte plugin is included in the configuration through the plugins array. Developers can customize this configuration according to the specific requirements and dependencies of their project.
